### PR TITLE
data-expounder style now applies to every element

### DIFF
--- a/expounder.css
+++ b/expounder.css
@@ -1,6 +1,5 @@
-span[data-expounder] {
-    text-decoration: none;
-    border-bottom: 1px dashed;
+*[data-expounder] {
+    text-decoration: underline;
     cursor: pointer;
 }
 

--- a/expounder.css
+++ b/expounder.css
@@ -1,5 +1,6 @@
 *[data-expounder] {
-    text-decoration: underline;
+    text-decoration: none;
+    border-bottom: 1px dashed;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Also data-expounder style uses text-decoration:underline instead of a dashed border
