### PR TITLE
Change gitcdn.xyz to rawgit.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
     <link href='https://fonts.googleapis.com/css?family=Playfair+Display' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Ovo|Muli:300' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="https://gitcdn.xyz/repo/skorokithakis/expounder/master/expounder.css" />
+    <link rel="stylesheet" href="https://rawgit.com/skorokithakis/expounder/master/expounder.css" />
     <style>
     * {
         margin: 0;
@@ -252,6 +252,6 @@
 
     <p class="copy">Made with ♥️ in Greece.</p>
 
-    <script src="https://gitcdn.xyz/repo/skorokithakis/expounder/master/expounder.js"></script>
+    <script src="https://rawgit.com/skorokithakis/expounder/master/expounder.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Hi!

The demonstration page seems broken (https://skorokithakis.github.io/expounder/) :cry: 

The browser fail to load the resources on the gitcdn.xyz domain, like this one https://gitcdn.xyz/repo/skorokithakis/expounder/master/expounder.css

I propose to change to rawgit.com

Cheers,
Thomas.